### PR TITLE
BSAPI-6: Fixes the issue of targeting wrong branch.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,10 +3,10 @@ name: Gradle Build & Spotless Check
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Fixed the `GitHub Actions` file `gradle.yml` to target the proper main branch called `master`.
To check this, above this description, on the tabs where it says `Conversation`, there is a tab that says `Checks`, that is where you can see that this branch is targeted properly, as per before, in the previous PR, we did not get a check which was not acceptable.